### PR TITLE
Feat: Add Spanish translation

### DIFF
--- a/HereToSlay/Languages/lang.json
+++ b/HereToSlay/Languages/lang.json
@@ -102,5 +102,32 @@
     "card_item_cursed": "Objet maudit",
     "card_magic_label": "Magie"
   },
+  {
+    "lang_name": "Español",
+    "lang_code": "es",
+    "class_name": [
+      /*no_class*/ "SIN CLASE",
+      /*ranger*/ "Cazador",
+      /*wizard*/ "Mago",
+      /*bard*/ "Bardo",
+      /*guardian*/ "Guardián",
+      /*fighter*/ "Guerrero",
+      /*thief*/ "Ladrón",
+      /*druid*/ "Druida",
+      /*warrior*/ "Espadachín",
+      /*berserker*/ "Berserker",
+      /*necromancer*/ "Nigromante",
+      /*sorcerer*/ "Hechizero"
+    ],
+    "card_leader_label": "Líder de Equipo",
+    "card_monster_label": "Monstruo",
+    "card_monster_requirements": "REQUISITOS:",
+    "card_monster_margin": 8,
+    "hero_symbol_letter": "",
+    "card_hero_label": "Héroe",
+    "card_item_label": "Objeto",
+    "card_item_cursed": "Objeto maldito",
+    "card_magic_label": "Magia"
+  },
   // Place the cursor after this coma and hit enter. Then copy the formula from Adding_New_Language.txt or from languages above
 ]

--- a/README.md
+++ b/README.md
@@ -220,7 +220,10 @@ After you have done all that, you should see your very own Here To Slay custom c
 
 ## Additional card language
 You don't want your cards in English? Don't worry, we have something for that!<br>
-Head over to <code>HereToSlay/Languages</code> folder. First, read through <code>Adding_New_Language.txt</code> and then, well, follow the instructions!<br>
+
+There's currently translations of the UI and cards in Polish, French and Spanish (in addition to English).
+
+If you want to add a new language on your own, head over to <code>HereToSlay/Languages</code> folder. First, read through <code>Adding_New_Language.txt</code> and then, well, follow the instructions!<br>
 Also in <code>lang.json</code> in English language object (the first one) we left some notes for you to understand which field is which, so make sure to read those notes also!<br>
 No, seriously. They ARE important.<br>
 


### PR DESCRIPTION
This PR adds native Spanish translation into the app.

Aditionally, the README.md (but no README.pl.md) has been updated to make explicit mention of currently translated languages.

Sources for the Spanish translation:
 - Base game I own.
 - [A community document ](https://boardgamegeek.com/filepage/236053/cartas-ks-y-expansiones-en-espanol) for some of the expansions.
 - [Promotional material](https://www.nonolandcr.com/products/here-to-slay-berserker-necromancer) for another expansion.